### PR TITLE
Fix: fix ORM instance getter

### DIFF
--- a/includes/CategoryCounter.php
+++ b/includes/CategoryCounter.php
@@ -45,7 +45,7 @@ class CategoryCounter extends SimpleHandler {
 
 		$services = MediaWikiServices::getInstance();
 		// TODO: 1.42+ 부터 replica DB는 $services->getConnectionProvider()->getReplicaDatabase()로 가져와야 한다.
-		$dbaseref = wfGetDB(DB_REPLICA);
+		$dbaseref = $services->getDBLoadBalancer()->getConnection( DB_REPLICA );
 
 		$resultarr = [];
 

--- a/includes/GetGameRatings.php
+++ b/includes/GetGameRatings.php
@@ -48,7 +48,7 @@ class GetGameRatings extends SimpleHandler {
 		$score_num = (string) $count;
 		$services = MediaWikiServices::getInstance();
 		// TODO: 1.42+ 부터 replica DB는 $services->getConnectionProvider()->getReplicaDatabase()로 가져와야 한다.
-		$dbaseref = wfGetDB(DB_REPLICA);
+		$dbaseref = $services->getDBLoadBalancer()->getConnection( DB_REPLICA );
 		$parsetarget = "";
 		
 		// $query는 stdClass 형의 변수임


### PR DESCRIPTION
### 변경점

1.42부터 변경된 ORM 호출 방식에 따라 MediaWikiServices::getInstance( )의 메서드를 통해 ORM을 호출합니다.